### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.1.0](https://github.com/muse254/layer8-primitives-rs/releases/tag/v0.1.0) - 2024-11-07
+
+### Other
+
+- name refactor
+- release-plz toml
+- carates io publish workflow
+- quality gate
+- initial commit
+
 ## [0.1.0] - 2024-11-07
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `layer8-primitives`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).